### PR TITLE
Alternating queues and Channel Hopping

### DIFF
--- a/_mocks/generated/discordclient/mock_client.go
+++ b/_mocks/generated/discordclient/mock_client.go
@@ -68,6 +68,20 @@ func (mr *MockDisgordClientAPIMockRecorder) SendMsg(arg0 interface{}, arg1 ...in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMsg", reflect.TypeOf((*MockDisgordClientAPI)(nil).SendMsg), varargs...)
 }
 
+// User mocks base method
+func (m *MockDisgordClientAPI) User(arg0 snowflake.Snowflake) disgord.UserQueryBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "User", arg0)
+	ret0, _ := ret[0].(disgord.UserQueryBuilder)
+	return ret0
+}
+
+// User indicates an expected call of User
+func (mr *MockDisgordClientAPIMockRecorder) User(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "User", reflect.TypeOf((*MockDisgordClientAPI)(nil).User), arg0)
+}
+
 // VoiceConnectOptions mocks base method
 func (m *MockDisgordClientAPI) VoiceConnectOptions(arg0, arg1 snowflake.Snowflake, arg2, arg3 bool) (disgord.VoiceConnection, error) {
 	m.ctrl.T.Helper()

--- a/discord/eventdelegation.go
+++ b/discord/eventdelegation.go
@@ -159,9 +159,9 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 		}
 		go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
 		go deleteMessage(resp, 30*time.Second, disgordGlobalClient)
-		// globalQueue.UserQueue[globalQueue.NowPlayinguID] = []string{globalQueue.UserQueue[globalQueue.NowPlayinguID][0]}
-		globalQueue.NowPlayinguID = 0
-		delete(globalQueue.UserQueue, globalQueue.NowPlayinguID)
+		// globalQueue.UserQueue[globalQueue.NowPlayingUID] = []string{globalQueue.UserQueue[globalQueue.NowPlayingUID][0]}
+		globalQueue.NowPlayingUID = 0
+		delete(globalQueue.UserQueue, globalQueue.NowPlayingUID)
 	default:
 		cec.Delegate()
 	}
@@ -214,4 +214,11 @@ func RespondToReaction(s disgord.Session, data *disgord.MessageReactionAdd) {
 // RespondToVoiceChannelUpdate updates the server's voice channel cache every time an update is emitted
 func RespondToVoiceChannelUpdate(s disgord.Session, data *disgord.VoiceStateUpdate) {
 	globalQueue.UpdateVoiceCache(data.ChannelID, data.UserID)
+	if data.ChannelID != 0 && data.UserID == globalQueue.NowPlayingUID && globalQueue.VoiceCache[data.UserID] != 0 {
+		fmt.Println("QUALIFIED JUMP!")
+		go func() {
+			globalQueue.ChannelHop <- data.ChannelID
+			return
+		}()
+	}
 }

--- a/discord/eventdelegation.go
+++ b/discord/eventdelegation.go
@@ -41,6 +41,9 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 		}()
 		go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
 	case "play":
+		if len(args) == 0 {
+			return
+		}
 		if strings.Contains(args[0], "list=") {
 			plis := ytService.PlaylistItems.List([]string{"snippet", "status", "contentDetails"})
 			ytc := yt.NewYoutubePlaylistClient(plis)

--- a/discord/eventdelegation.go
+++ b/discord/eventdelegation.go
@@ -10,8 +10,9 @@ import (
 	"github.com/andersfylling/disgord"
 )
 
-// Using this for access to the global clients FOR NOW as passing it through the handlers has proven tricky
-// TO-DO find a solution to get rid of the global variables
+// Goal is to have this file as small as possible, the purpose of this file isn't about delegation so to say
+// It's acting as an intermediary; separating global vars from the business logic
+// This means the more code/logic I can get out of this file, the more code/logic that can be unit tested via dependency injection
 
 // RespondToCommand delegates actions when commands are issued
 func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
@@ -42,6 +43,26 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 		go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
 	case "play":
 		if len(args) == 0 {
+			resp, err := disgordGlobalClient.SendMsg(
+				data.Message.ChannelID,
+				&disgord.CreateMessageParams{
+					Embed: &disgord.Embed{
+						Title:       "**Empty Request**",
+						Description: "*You didn't request anything*",
+
+						Footer: &disgord.EmbedFooter{
+							Text: fmt.Sprintf("*%+v only provided the play command*", data.Message.Author.Username),
+						},
+						Timestamp: data.Message.Timestamp,
+						Color:     0xeec400,
+					},
+				},
+			)
+			if err != nil {
+				fmt.Printf("\nERROR ADDING TO QUEUE: %+v\n", err)
+			}
+			go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
+			go deleteMessage(resp, 7*time.Second, disgordGlobalClient)
 			return
 		}
 		if strings.Contains(args[0], "list=") {
@@ -73,7 +94,7 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 				}
 				globalQueue.UpdateUserQueueStateBulk(data.Message.ChannelID, data.Message.Author.ID, urls)
 				go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
-				go deleteMessage(resp, 30*time.Second, disgordGlobalClient)
+				go deleteMessage(resp, 7*time.Second, disgordGlobalClient)
 			} else {
 				resp, err := disgordGlobalClient.SendMsg(
 					data.Message.ChannelID,
@@ -94,7 +115,7 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 					fmt.Printf("\nERROR ADDING TO QUEUE: %+v\n", err)
 				}
 				go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
-				go deleteMessage(resp, 30*time.Second, disgordGlobalClient)
+				go deleteMessage(resp, 7*time.Second, disgordGlobalClient)
 			}
 		} else {
 			if globalQueue.VoiceCache[data.Message.Author.ID] != 0 {
@@ -118,7 +139,7 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 				}
 				globalQueue.UpdateUserQueueState(data.Message.ChannelID, data.Message.Author.ID, args[0])
 				go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
-				go deleteMessage(resp, 30*time.Second, disgordGlobalClient)
+				go deleteMessage(resp, 7*time.Second, disgordGlobalClient)
 			} else {
 				resp, err := disgordGlobalClient.SendMsg(
 					data.Message.ChannelID,
@@ -162,9 +183,8 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 			fmt.Printf("\nERROR CREATING PURGE MESSAGE: %+v\n", err)
 		}
 		go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
-		go deleteMessage(resp, 30*time.Second, disgordGlobalClient)
+		go deleteMessage(resp, 7*time.Second, disgordGlobalClient)
 		// globalQueue.UserQueue[globalQueue.NowPlayingUID] = []string{globalQueue.UserQueue[globalQueue.NowPlayingUID][0]}
-		globalQueue.NowPlayingUID = 0
 		delete(globalQueue.UserQueue, globalQueue.NowPlayingUID)
 	default:
 		cec.Delegate()
@@ -173,7 +193,6 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 
 // RespondToMessage delegates actions when messages are created
 func RespondToMessage(s disgord.Session, data *disgord.MessageCreate) {
-
 	switch data.Message.ChannelID {
 	case 779836590503624734:
 		data.Message.React(ctx, s, "\u26D4")
@@ -183,7 +202,6 @@ func RespondToMessage(s disgord.Session, data *disgord.MessageCreate) {
 		data.Message.React(ctx, s, "\u23E9")
 		time.Sleep(1 * time.Second)
 	}
-
 	user := data.Message.Author
 	fmt.Printf("Message %+v by user %+v | %+v\n", data.Message.Content, user.Username, time.Now().Format("Mon Jan _2 15:04:05 2006"))
 	mec := NewMessageEventClient(data.Message, disgordGlobalClient)

--- a/discord/eventdelegation.go
+++ b/discord/eventdelegation.go
@@ -42,8 +42,9 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 		go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
 	case "play":
 		if strings.Contains(args[0], "list=") {
-			plis := ytService.PlaylistItems.List([]string{"snippet"})
-			ytc := yt.NewYoutubeClient(plis)
+			plis := ytService.PlaylistItems.List([]string{"snippet", "status", "contentDetails"})
+			ytc := yt.NewYoutubePlaylistClient(plis)
+
 			urls, err := ytc.GetPlaylist(args[0])
 			if err != nil {
 				fmt.Printf("\nERROR GETTING PLAYLIST URLS: %+v\n", err)
@@ -214,8 +215,7 @@ func RespondToReaction(s disgord.Session, data *disgord.MessageReactionAdd) {
 // RespondToVoiceChannelUpdate updates the server's voice channel cache every time an update is emitted
 func RespondToVoiceChannelUpdate(s disgord.Session, data *disgord.VoiceStateUpdate) {
 	globalQueue.UpdateVoiceCache(data.ChannelID, data.UserID)
-	if data.ChannelID != 0 && data.UserID == globalQueue.NowPlayingUID && globalQueue.VoiceCache[data.UserID] != 0 {
-		fmt.Println("QUALIFIED JUMP!")
+	if data.ChannelID != 0 && data.ChannelID != globalQueue.VoiceCache[739154323015204935] && data.UserID == globalQueue.NowPlayingUID && globalQueue.VoiceCache[data.UserID] != 0 {
 		go func() {
 			globalQueue.ChannelHop <- data.ChannelID
 			return

--- a/discord/eventdelegation.go
+++ b/discord/eventdelegation.go
@@ -67,7 +67,7 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 				if err != nil {
 					fmt.Printf("\nERROR ADDING TO QUEUE: %+v\n", err)
 				}
-				globalQueue.UpdateQueueStateBulk(data.Message.ChannelID, data.Message.Author.ID, urls)
+				globalQueue.UpdateUserQueueStateBulk(data.Message.ChannelID, data.Message.Author.ID, urls)
 				go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
 				go deleteMessage(resp, 30*time.Second, disgordGlobalClient)
 			} else {
@@ -112,7 +112,7 @@ func RespondToCommand(s disgord.Session, data *disgord.MessageCreate) {
 				if err != nil {
 					fmt.Printf("\nERROR ADDING TO QUEUE: %+v\n", err)
 				}
-				globalQueue.UpdateQueueState(data.Message.ChannelID, data.Message.Author.ID, args[0])
+				globalQueue.UpdateUserQueueState(data.Message.ChannelID, data.Message.Author.ID, args[0])
 				go deleteMessage(data.Message, 1*time.Second, disgordGlobalClient)
 				go deleteMessage(resp, 30*time.Second, disgordGlobalClient)
 			} else {
@@ -177,6 +177,7 @@ func RespondToMessage(s disgord.Session, data *disgord.MessageCreate) {
 		data.Message.React(ctx, s, "\u267B")
 		time.Sleep(1 * time.Second)
 		data.Message.React(ctx, s, "\u23E9")
+		time.Sleep(1 * time.Second)
 	}
 
 	user := data.Message.Author

--- a/discord/ifaces/clientAPI.go
+++ b/discord/ifaces/clientAPI.go
@@ -12,6 +12,7 @@ type DisgordClientAPI interface {
 	// GetMessage(channelID, messageID disgord.Snowflake) (ret *disgord.Message, err error)
 	VoiceConnectOptions(guildID, channelID disgord.Snowflake, selfDeaf, selfMute bool) (ret disgord.VoiceConnection, err error)
 	Channel(id disgord.Snowflake) disgord.ChannelQueryBuilder
+	User(id disgord.Snowflake) disgord.UserQueryBuilder
 }
 
 // DisgordMessageQueryBuilderAPI provides an interface for mocking Disgord's MessageQueryBuilder behavior

--- a/discord/queue.go
+++ b/discord/queue.go
@@ -235,7 +235,7 @@ func (q *Queue) ManageJukebox(disgordClient disgordiface.DisgordClientAPI) {
 				if err != nil {
 					fmt.Println("\n", err)
 				}
-				avatarURL, err := requesteeName.AvatarURL(1024, true)
+				avatarURL, err := requesteeName.AvatarURL(64, true)
 				if err != nil {
 					fmt.Println("\n", err)
 				}
@@ -249,21 +249,19 @@ func (q *Queue) ManageJukebox(disgordClient disgordiface.DisgordClientAPI) {
 					779836590503624734,
 					&disgord.CreateMessageParams{
 						Embed: &disgord.Embed{
-							Title: "**Song info**",
+							Thumbnail: &disgord.EmbedThumbnail{
+								URL:    avatarURL,
+								Height: 64,
+								Width:  64,
+							},
 							Fields: []*disgord.EmbedField{
 								&disgord.EmbedField{
 									Name:  "Requested by",
 									Value: requesteeName.Username,
 								},
-								&disgord.EmbedField{
-									Name:  fmt.Sprintf("Songs left in %+v's queue", requesteeName.Username),
-									Value: strconv.Itoa(len(q.UserQueue[q.NowPlayinguID])),
-								},
 							},
-							Image: &disgord.EmbedImage{
-								URL:    avatarURL,
-								Height: 48,
-								Width:  48,
+							Footer: &disgord.EmbedFooter{
+								Text: fmt.Sprintf("%+v's queue: %+v", requesteeName.Username, strconv.Itoa(len(q.UserQueue[q.NowPlayinguID]))),
 							},
 						},
 					},

--- a/discord/queue.go
+++ b/discord/queue.go
@@ -110,7 +110,6 @@ func (q *Queue) ListenAndProcessQueue(disgordClientAPI disgordiface.DisgordClien
 			q.setNowPlaying()
 			requestURL := ""
 			requestURL = fmt.Sprintf("http://localhost:8080/mp3/%+v", q.UserQueue[q.NowPlayingUID][0])
-			// q.NowPlayingSync(requestURL)
 			fmt.Println("\nURL: ", q.NowPlayingURL)
 			fields := strings.Split(q.UserQueue[q.NowPlayingUID][0], "=")
 			id := fields[1]
@@ -270,14 +269,6 @@ func (q *Queue) ManageJukebox(disgordClient disgordiface.DisgordClientAPI) {
 				if err != nil {
 					fmt.Println("\n", err)
 				}
-				// if q.NextPlayingUID != 0 {
-				// 	uName, err := disgordClient.User(q.NextPlayingUID).Get()
-				// 	if err != nil {
-				// 		fmt.Println("\n", err)
-				// 	}
-				// 	nextRequesteeName = uName.Username
-				// }
-
 				avatarURL, err := requesteeName.AvatarURL(64, true)
 				if err != nil {
 					fmt.Println("\n", err)
@@ -374,23 +365,6 @@ func (q *Queue) EmptyQueue() {
 	delete(q.UserQueue, q.NowPlayingUID)
 	q.LastPlayingUID = q.NowPlayingUID
 }
-
-// NowPlayingSync keeps the NowPlayingUID updated with the ID of the user who's song is currently playing
-// And updates the NowPlayingURL with the currently playing song's URL
-// func (q *Queue) NowPlayingSync(url string) {
-// 	fields := strings.Split(url, "mp3/")
-// 	currentUID := disgord.Snowflake(0)
-// 	i := 0
-// 	for idKey, stringArr := range q.UserQueue {
-// 		for _, url := range stringArr {
-// 			if url == fields[1] {
-// 				currentUID = idKey
-// 			}
-// 		}
-// 		i++
-// 	}
-// 	q.NowPlayingUID = currentUID
-// }
 
 func (q *Queue) stopPlaybackAndTalking(vc disgord.VoiceConnection, es *dca.EncodeSession) {
 	err := es.Stop()

--- a/discord/run.go
+++ b/discord/run.go
@@ -46,8 +46,7 @@ func BotRun(client *disgord.Client, cf config.ConfJSONStruct, creds *config.Boom
 	globalQueue = queue
 	disgordGlobalClient = client
 	ytService, _ = youtube.NewService(ctx, option.WithAPIKey(creds.YoutubeToken))
-	bleh := ytService.Videos.List([]string{"contentDetails", "snippet"})
-
+	bleh := ytService.Videos.List([]string{"contentDetails", "snippet", "statistics"})
 	filter, _ := std.NewMsgFilter(ctx, client)
 	filter.SetPrefix(cf.Prefix)
 	client.Gateway().WithMiddleware(filter.NotByBot, filter.HasPrefix, std.CopyMsgEvt, filter.StripPrefix).MessageCreate(RespondToCommand)
@@ -55,7 +54,6 @@ func BotRun(client *disgord.Client, cf config.ConfJSONStruct, creds *config.Boom
 	client.Gateway().VoiceStateUpdate(RespondToVoiceChannelUpdate)
 	client.Gateway().MessageCreate(RespondToMessage)
 	fmt.Println("BoomBot is running")
-
 	go globalQueue.ListenAndProcessQueue(client, bleh)
 	go globalQueue.ManageJukebox(client)
 	defer client.Gateway().StayConnectedUntilInterrupted()

--- a/discord/run.go
+++ b/discord/run.go
@@ -44,9 +44,10 @@ func BotRun(client *disgord.Client, cf config.ConfJSONStruct, creds *config.Boom
 	conf = cf
 	queue := NewQueue(disgord.ParseSnowflakeString(conf.GuildID))
 	globalQueue = queue
-
 	disgordGlobalClient = client
 	ytService, _ = youtube.NewService(ctx, option.WithAPIKey(creds.YoutubeToken))
+	bleh := ytService.Videos.List([]string{"contentDetails", "snippet"})
+
 	filter, _ := std.NewMsgFilter(ctx, client)
 	filter.SetPrefix(cf.Prefix)
 	client.Gateway().WithMiddleware(filter.NotByBot, filter.HasPrefix, std.CopyMsgEvt, filter.StripPrefix).MessageCreate(RespondToCommand)
@@ -54,7 +55,8 @@ func BotRun(client *disgord.Client, cf config.ConfJSONStruct, creds *config.Boom
 	client.Gateway().VoiceStateUpdate(RespondToVoiceChannelUpdate)
 	client.Gateway().MessageCreate(RespondToMessage)
 	fmt.Println("BoomBot is running")
-	go globalQueue.ListenAndProcessQueue(client)
+
+	go globalQueue.ListenAndProcessQueue(client, bleh)
 	go globalQueue.ManageJukebox(client)
 	defer client.Gateway().StayConnectedUntilInterrupted()
 }

--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	google.golang.org/api v0.33.0
 )
+
+// replace github.com/andersfylling/disgord => ../disgord

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
@@ -161,6 +162,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -240,6 +242,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -540,6 +543,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -648,6 +652,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
@@ -666,6 +671,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 nhooyr.io/websocket v1.7.4 h1:w/LGB2sZT0RV8lZYR7nfyaYz4PUbYZ5oF7NBon2M0NY=
 nhooyr.io/websocket v1.7.4/go.mod h1:PxYxCwFdFYQ0yRvtQz3s/dC+VEm7CSuC/4b9t8MQQxw=
 nhooyr.io/websocket v1.8.6 h1:s+C3xAMLwGmlI31Nyn/eAehUlZPwfYZu2JXM621Q5/k=
@@ -673,3 +680,4 @@ nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var log = &logrus.Logger{
 	Out:       os.Stderr,
 	Formatter: new(logrus.TextFormatter),
 	Hooks:     make(logrus.LevelHooks),
-	Level:     logrus.DebugLevel,
+	Level:     logrus.ErrorLevel,
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var log = &logrus.Logger{
 	Out:       os.Stderr,
 	Formatter: new(logrus.TextFormatter),
 	Hooks:     make(logrus.LevelHooks),
-	Level:     logrus.ErrorLevel,
+	Level:     logrus.DebugLevel,
 }
 
 func main() {

--- a/youtube/ifaces/clientAPI.go
+++ b/youtube/ifaces/clientAPI.go
@@ -6,11 +6,20 @@ import (
 
 // YoutubeSearchServiceAPI provides an interface for mocking youtube search service service behavior
 type YoutubeSearchServiceAPI interface {
-	List(part []string) *youtube.SearchListCall
+	Q(q string) *youtube.SearchListCall
+}
+
+type YoutubeVideoDetailsAPI interface {
+	Q(q string) *youtube.VideosListCall
 }
 
 // YoutubePlaylistItemsServiceAPI provides and interface for mocking youtube playlistitems service behavior
 type YoutubePlaylistItemsServiceAPI interface {
 	PlaylistId(playlistID string) *youtube.PlaylistItemsListCall
 	// Do(opts ...googleapi.CallOption) (*youtube.PlaylistItemListResponse, error)
+}
+
+type YoutubeVideoItemServiceAPI interface {
+	List(part []string) *youtube.VideosListCall
+	// Do(opts ...googleapi.CallOption) (*youtube.VideoListResponse, error)
 }

--- a/youtube/videoclient.go
+++ b/youtube/videoclient.go
@@ -1,0 +1,34 @@
+package yt
+
+import (
+	youtubeiface "github.com/aplombomb/boombot/youtube/ifaces"
+)
+
+type VideoClient struct {
+	YoutubeVideoClient youtubeiface.YoutubeSearchServiceAPI
+}
+
+type VideoClientTest struct {
+	YoutubeVideoDetails youtubeiface.YoutubeVideoDetailsAPI
+}
+
+func NewVideoClient(vc youtubeiface.YoutubeSearchServiceAPI) *VideoClient {
+	return &VideoClient{
+		YoutubeVideoClient: vc,
+	}
+}
+
+func NewVideoClientTest(vcd youtubeiface.YoutubeVideoDetailsAPI) *VideoClientTest {
+	return &VideoClientTest{
+		YoutubeVideoDetails: vcd,
+	}
+}
+
+func (c *VideoClient) GetVideoDetails(id string) {
+	// resp := c.YoutubeVideoClient.Q(id)
+	// slr, err := resp.Do()
+	// if err != nil {
+	// 	fmt.Println("\nERROR FETCHING SONG INFO: ", err)
+	// }
+	// fmt.Println("\nSONG NAME: ", slr.Items[0].Snippet.Title)
+}


### PR DESCRIPTION
Improves the group listening experience by cycling through the collection of user queues each iteration rather than playing only the songs from the first queue.

The bot now follows the user whose song is currently playing in real-time, if they move to another voice channel.