### PR TITLE
Application Commands setup | Dead goRoutine hotfix

### DIFF
--- a/commandreg/play.go
+++ b/commandreg/play.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+type CommandInfo struct {
+	Name        string          `json:"name"`
+	Description string          `json:"Description"`
+	Options     []CommandOption `json:"Options"`
+}
+
+type CommandOption struct {
+	Name        string          `json:"Name"`
+	Description string          `json:"Description"`
+	Type        int             `json:"Type"`
+	Required    bool            `json:"required"`
+	Choices     []CommandChoice `json:"choices"`
+}
+
+type CommandChoice struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Type  int    `json:"type"`
+}
+
+func main() {
+	botToken := os.Getenv("BOOMBOT_TOKEN")
+	// fmt.Println("Token: ", botToken)
+	testCommand := CommandInfo{
+		Name:        "Test",
+		Description: "A test command for BoomBot's slash command functionality",
+		Options: []CommandOption{
+			CommandOption{
+				Name:        "Option1",
+				Description: "First option",
+				Type:        2,
+				Required:    true,
+				Choices: []CommandChoice{
+					CommandChoice{
+						Name:  "First Choice",
+						Value: "first_choice",
+						Type:  3,
+					},
+					CommandChoice{
+						Name:  "Second Choice",
+						Value: "second_choice",
+						Type:  1,
+					},
+				},
+			},
+		},
+	}
+
+	timeout := time.Duration(5 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	requestBody, err := json.Marshal(testCommand)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Req body: ", string(requestBody))
+
+	request, err := http.NewRequest("POST", "https://discord.com/api/v8/applications/739154323015204935/commands", bytes.NewBuffer(requestBody))
+	request.Header.Set("Authorization", fmt.Sprintf("Bot %+v", botToken))
+	request.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		panic(err)
+	}
+
+	// fmt.Println("Request: ", requestBody)
+
+	resp, err := client.Do(request)
+	if err != nil {
+		panic(err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	log.Panicln(string(body))
+}

--- a/commandreg/play.go
+++ b/commandreg/play.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -13,14 +11,14 @@ import (
 
 type CommandInfo struct {
 	Name        string          `json:"name"`
-	Description string          `json:"Description"`
-	Options     []CommandOption `json:"Options"`
+	Description string          `json:"description"`
+	Options     []CommandOption `json:"options"`
 }
 
 type CommandOption struct {
-	Name        string          `json:"Name"`
-	Description string          `json:"Description"`
-	Type        int             `json:"Type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Type        int             `json:"type"`
 	Required    bool            `json:"required"`
 	Choices     []CommandChoice `json:"choices"`
 }
@@ -33,30 +31,12 @@ type CommandChoice struct {
 
 func main() {
 	botToken := os.Getenv("BOOMBOT_TOKEN")
+	guildID := os.Getenv("GUILD_ID")
 	// fmt.Println("Token: ", botToken)
 	testCommand := CommandInfo{
 		Name:        "Test",
-		Description: "A test command for BoomBot's slash command functionality",
-		Options: []CommandOption{
-			CommandOption{
-				Name:        "Option1",
-				Description: "First option",
-				Type:        2,
-				Required:    true,
-				Choices: []CommandChoice{
-					CommandChoice{
-						Name:  "First Choice",
-						Value: "first_choice",
-						Type:  3,
-					},
-					CommandChoice{
-						Name:  "Second Choice",
-						Value: "second_choice",
-						Type:  1,
-					},
-				},
-			},
-		},
+		Description: "A test command for BoomBot slash command functionality",
+		Options:     []CommandOption{},
 	}
 
 	timeout := time.Duration(5 * time.Second)
@@ -71,7 +51,9 @@ func main() {
 
 	fmt.Println("Req body: ", string(requestBody))
 
-	request, err := http.NewRequest("POST", "https://discord.com/api/v8/applications/739154323015204935/commands", bytes.NewBuffer(requestBody))
+	reqURL := fmt.Sprintf("https://discord.com/api/v8/applications/739154323015204935/guilds/%+v/commands", guildID)
+
+	request, err := http.NewRequest("POST", reqURL, bytes.NewBuffer(requestBody))
 	request.Header.Set("Authorization", fmt.Sprintf("Bot %+v", botToken))
 	request.Header.Set("Content-Type", "application/json")
 	if err != nil {
@@ -87,9 +69,9 @@ func main() {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-	log.Panicln(string(body))
+	// body, err := ioutil.ReadAll(resp.Body)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// log.Panicln(string(body))
 }

--- a/discord/eventdelegation.go
+++ b/discord/eventdelegation.go
@@ -89,6 +89,7 @@ func RespondToPresenceUpdate(s disgord.Session, data *disgord.PresenceUpdate) {
 	managedRoles := []disgord.Snowflake{787758251574820864, 737467990647373827, 735890320348282880}
 	gameEvent, _ := data.Game()
 	fmt.Println("GameEvent: ", gameEvent)
+	fmt.Println("User: ", data.User.Username)
 	if gameEvent == nil {
 		fmt.Println("This must have been an online/offline event")
 		return

--- a/discord/queue.go
+++ b/discord/queue.go
@@ -220,27 +220,29 @@ func (q *Queue) ListenAndProcessQueue(disgordClientAPI disgordiface.DisgordClien
 				defer es.Cleanup()
 				defer ticker.Stop()
 				defer waitGroup.Done()
+				defer fmt.Println("Leaving goroutine")
 				for {
 					select {
 					case <-q.Shuffle:
 						q.stopPlaybackAndTalking(vc, es)
 						q.ShuffleQueue()
-						time.Sleep(1 * time.Second)
+						// time.Sleep(1 * time.Second)
 						return
 					case <-q.Stop:
 						q.stopPlaybackAndTalking(vc, es)
 						q.EmptyQueue()
-						time.Sleep(1 * time.Second)
+						// time.Sleep(1 * time.Second)
 						return
 					case <-q.Next:
 						q.stopPlaybackAndTalking(vc, es)
 						q.RemoveQueueEntry()
-						time.Sleep(1 * time.Second)
+						fmt.Println("Entry removed, returning....")
+						// time.Sleep(1 * time.Second)
 						return
 					case <-done:
 						q.stopPlaybackAndTalking(vc, es)
 						q.RemoveQueueEntry()
-						time.Sleep(1 * time.Second)
+						// time.Sleep(1 * time.Second)
 						return
 					case channelID := <-q.ChannelHop:
 						vc.StopSpeaking()
@@ -263,6 +265,7 @@ func (q *Queue) ListenAndProcessQueue(disgordClientAPI disgordiface.DisgordClien
 							fmt.Printf("\nError sending next opus frame: %+v\n", err)
 						}
 						if err == io.EOF {
+							fmt.Println("EOF, sending true to eofChannel...")
 							eofChannel <- true
 						}
 						vc.SendOpusFrame(nextFrame)
@@ -465,7 +468,7 @@ func (q *Queue) stopPlaybackAndTalking(vc disgord.VoiceConnection, es *dca.Encod
 
 func (q *Queue) establishVoiceConnection(prevVC disgord.VoiceConnection, client disgordiface.DisgordClientAPI, guild disgordiface.GuildQueryBuilderAPI, botChannelID disgord.Snowflake, requesteeChannelID disgord.Snowflake) (disgord.VoiceConnection, error) {
 	if botChannelID == 0 {
-		vc, err := guild.VoiceChannel(requesteeChannelID).Connect(true, false)
+		vc, err := guild.VoiceChannel(requesteeChannelID).Connect(false, true)
 		if err != nil {
 			return nil, err
 		}

--- a/discord/queue.go
+++ b/discord/queue.go
@@ -217,6 +217,7 @@ func (q *Queue) ListenAndProcessQueue(disgordClientAPI disgordiface.DisgordClien
 			// Goroutine just cycles through the opusFrames produced from the encoding process
 			// The channels allow for realtime interaction/playback control from events triggered by users
 			go func(waitGroup *sync.WaitGroup) {
+				fmt.Println("Main goroutine started")
 				defer es.Cleanup()
 				defer ticker.Stop()
 				defer waitGroup.Done()
@@ -252,7 +253,7 @@ func (q *Queue) ListenAndProcessQueue(disgordClientAPI disgordiface.DisgordClien
 						}
 						err = vc.StartSpeaking()
 						if err != nil {
-							fmt.Println("\nError starting speaking: ", err)
+							fmt.Println("Error starting speaking: \n", err)
 						}
 					case <-q.Pause:
 						ticker.Stop()
@@ -272,7 +273,11 @@ func (q *Queue) ListenAndProcessQueue(disgordClientAPI disgordiface.DisgordClien
 					}
 				}
 			}(&wg)
-			go func() {
+			go func(waitGroup *sync.WaitGroup) {
+				waitGroup.Add(1)
+				defer waitGroup.Done()
+				fmt.Println("Secondary goroutine started")
+				defer fmt.Println("Leaving secondary goroutine")
 				for {
 					time.Sleep(1 * time.Second)
 					select {
@@ -281,7 +286,7 @@ func (q *Queue) ListenAndProcessQueue(disgordClientAPI disgordiface.DisgordClien
 						return
 					}
 				}
-			}()
+			}(&wg)
 		}
 		wg.Wait()
 		if len(q.UserQueue) == 0 {

--- a/discord/roles.go
+++ b/discord/roles.go
@@ -1,0 +1,4 @@
+package discord
+
+type RoleManagementClient struct {
+}

--- a/discord/roles_test.go
+++ b/discord/roles_test.go
@@ -1,0 +1,1 @@
+package discord

--- a/discord/run.go
+++ b/discord/run.go
@@ -32,9 +32,9 @@ var globalQueue *Queue
 const Version = "v1.0.0-alpha"
 
 const (
-	host   = "localhost"
+	host   = "db"
 	port   = 5432
-	dbname = "postgres"
+	dbname = "bomb"
 )
 
 func init() {

--- a/discord/run.go
+++ b/discord/run.go
@@ -2,10 +2,7 @@ package discord
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"log"
-	"os"
 
 	"google.golang.org/api/option"
 	"google.golang.org/api/youtube/v3"
@@ -31,11 +28,11 @@ var globalQueue *Queue
 // Version of BoomBot
 const Version = "v1.0.0-alpha"
 
-const (
-	host   = "pgDB"
-	port   = 5432
-	dbname = "bomb"
-)
+// const (
+// 	host   = "pgDB"
+// 	port   = 5432
+// 	dbname = "bomb"
+// )
 
 func init() {
 
@@ -49,19 +46,19 @@ func init() {
 
 // BotRun | Start the bot and react to events
 func BotRun(client *disgord.Client, prefix string, gID string, yk string) {
-	dbUser := os.Getenv("POSTGRES_USER")
-	dbPass := os.Getenv("POSTGRES_PASSWORD")
-	pgCreds := fmt.Sprintf("host=%s port=%d user=%s "+
-		"password=%s dbname=%s sslmode=disable",
-		host, port, dbUser, dbPass, dbname)
-	db, err := sql.Open("postgres", pgCreds)
-	if err != nil {
-		log.Fatal("\nError connecting to DB: ", err)
-	}
-	err = db.Ping()
-	if err != nil {
-		panic(err)
-	}
+	// dbUser := os.Getenv("POSTGRES_USER")
+	// dbPass := os.Getenv("POSTGRES_PASSWORD")
+	// pgCreds := fmt.Sprintf("host=%s port=%d user=%s "+
+	// 	"password=%s dbname=%s sslmode=disable",
+	// 	host, port, dbUser, dbPass, dbname)
+	// db, err := sql.Open("postgres", pgCreds)
+	// if err != nil {
+	// 	log.Fatal("\nError connecting to DB: ", err)
+	// }
+	// err = db.Ping()
+	// if err != nil {
+	// 	panic(err)
+	// }
 	queue := NewQueue(disgord.ParseSnowflakeString(gID))
 	globalQueue = queue
 	disgordGlobalClient = client

--- a/discord/run.go
+++ b/discord/run.go
@@ -32,7 +32,7 @@ var globalQueue *Queue
 const Version = "v1.0.0-alpha"
 
 const (
-	host   = "pgDB"
+	host   = "localhost"
 	port   = 5432
 	dbname = "postgres"
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,12 @@ services:
         - boombot.env
         - db.env
     # image: aplombomb/boombot
-    image: boombot-local-dev
+    image: boombot-local-dev:latest
     container_name: boombot
     restart: on-failure
     links:
       - yt-api
+      - db
     depends_on:
       - yt-api
       - db
@@ -45,6 +46,8 @@ services:
       - db
     ports: 
       - "8080:8080"
+    links:
+      - db
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     env_file: 
         - boombot.env
         - db.env
-    # image: aplombomb/boombot
-    image: boombot-local-dev:latest
+    image: aplombomb/boombot:latest
+    # image: boombot-local-dev:latest
     container_name: boombot
     restart: on-failure
     links:

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 		RejectEvents: []string{
 			disgord.EvtTypingStart,
 			disgord.EvtGuildMemberAdd,
-			// disgord.EvtPresenceUpdate,
+			disgord.EvtPresenceUpdate,
 			disgord.EvtGuildMemberUpdate,
 			disgord.EvtGuildMemberRemove,
 		},

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 		RejectEvents: []string{
 			disgord.EvtTypingStart,
 			disgord.EvtGuildMemberAdd,
-			disgord.EvtPresenceUpdate,
+			// disgord.EvtPresenceUpdate,
 			disgord.EvtGuildMemberUpdate,
 			disgord.EvtGuildMemberRemove,
 		},


### PR DESCRIPTION
Addresses the dead goroutine scenario when one would finish before the other by tying the secondary routine to the waitgroup (not sure why it wasn't to begin with 🤷 )

Successfully added a guild "test" command and will work on handling incoming event triggered by it in next pr.

Database correctly setup and boombot able to successfully ping it on startup || models and playlist saving support coming soon